### PR TITLE
Update to bindgen 0.69.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,4 @@ maintenance = { status = "passively-maintained" }
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.51.1"
+bindgen = "0.69.4"


### PR DESCRIPTION
The old 0.51.1 would panic with:
```
  thread 'main' panicked at /home/kmkaplan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bindgen-0.51.1/src/ir/context.rs:891:9:
  "__atomic_wide_counter_struct_(unnamed_at_/usr/include/x86_64-linux-gnu/bits/atomic_wide_counter_h_28_3)" is not a valid Ident
```